### PR TITLE
chore: add CODEOWNERS to release/v1.2.3-spa

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything
+* @ben-del-cmd


### PR DESCRIPTION
- Add `.github/CODEOWNERS` on `release/v1.2.3-spa`
- Default owner: @ben-del-cmd
- Purpose: enable Code Owners review + protect the release branch (matches current ruleset)

Checklist
- [x] CODEOWNERS file passes validation
- [x] Base = release/v1.2.3-spa, Compare = main
