### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!-- deploy: 2025-10-06 · hotfix-20251006i (remember prefs + reset + localized factor labels) -->
+<!-- deploy: 2025-10-06 · hotfix-20251006j (per-species&stage factor memory) -->
 <!doctype html>
 <html lang="en">
 <head>
@@ -56,22 +56,16 @@ hr{border:none;border-top:1px solid #1f2b44;margin:10px 0}
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap:12px 14px;
 }
-/* 卡片外观 */
-#calc .factor-row .label-inline{
-  align-items:flex-start;gap:10px;padding:12px;background:#0f1930;border:1px solid #24324f;border-radius:12px;
-}
-/* 让圆点更贴近文字、更靠左、更紧凑（仅视觉微调） */
+/* 卡片外观（紧凑左对齐） */
 #calc .factor-row .label-inline{
   display:grid;
   grid-template-columns:auto 1fr;
   align-items:center;
   gap:8px;
   padding:10px 12px;
+  background:#0f1930;border:1px solid #24324f;border-radius:12px;
 }
-#calc .factor-row input[type="radio"]{
-  margin:0;
-  transform:translateY(-1px);
-}
+#calc .factor-row input[type="radio"]{margin:0;transform:translateY(-1px)}
 #calc .factor-row .label-inline > span{line-height:1.15}
 
 /* 7-Day 单列 */
@@ -142,7 +136,6 @@ hr{border:none;border-top:1px solid #1f2b44;margin:10px 0}
     <div class="card">
       <div style="display:flex;justify-content:space-between;align-items:center;gap:8px">
         <h2 data-i18n="calc.title" style="margin:0">Feeding Calculator</h2>
-        <!-- Reset saved（清空本地记忆）-->
         <a id="resetSaved" href="#" class="muted" style="font-size:.9em;text-decoration:none">Reset saved</a>
       </div>
 
@@ -172,9 +165,7 @@ hr{border:none;border-top:1px solid #1f2b44;margin:10px 0}
 
       <fieldset class="card" style="padding:12px">
         <legend data-i18n="calc.activity">Activity / life stage (MER factor)</legend>
-
         <div id="factors" class="factor-row" role="radiogroup" aria-label="MER factor"></div>
-
         <p class="muted" data-i18n="calc.factorHint">Labels show the actual factor used.</p>
         <p class="hint muted" data-i18n="calc.infoTip">Info (i): RER=70×kg^0.75; MER=RER×factor. Factors are a starting point—adjust by body condition & stool; special stages/diseases: follow your vet.</p>
 
@@ -189,7 +180,6 @@ hr{border:none;border-top:1px solid #1f2b44;margin:10px 0}
 
       <fieldset class="card" style="padding:12px">
         <legend data-i18n="calc.density">Optional: density for precise grams/cups</legend>
-
         <div class="form-grid">
           <div>
             <label for="kcal100" data-i18n="calc.kcal100">kcal / 100 g</label>
@@ -204,7 +194,6 @@ hr{border:none;border-top:1px solid #1f2b44;margin:10px 0}
             <input id="gPerCup" type="number" min="1" step="1" placeholder="—" />
           </div>
         </div>
-
         <p class="hint muted" data-i18n="calc.cupsNote">Cups calculation needs the food energy density (kcal/100g or kcal/cup) and grams per cup (often on the bag). If unknown, rely on grams/day first.</p>
       </fieldset>
 
@@ -278,10 +267,10 @@ hr{border:none;border-top:1px solid #1f2b44;margin:10px 0}
 </main>
 
 <script>
-/* ---------- I18N（保留原有） ---------- */
-const I18N={en:{nav:{home:"Home",calc:"Calc",switch:"7-Day",feedback:"Feedback"},ui:{lang:"Language"},home:{title:"Feeding & Switch Helper",pitch:"Informational tool for the U.S. market: turn pet food / grooming labels into actionable guidance. Not medical advice.",kcal:"RER/MER transparent",i18n:"Multi-language",mode:"Single-file SPA",quick:"Quick start",q1:"Go to Calc → enter weight (kg) → pick species & activity factor.",q2:"Review kcal/day and grams/day. Cups/day requires density info from the bag.",q3:"See 7-Day gradual switch plan. If stool soft or upset → hold or step back."},calc:{title:"Feeding Calculator",species:"Species",weight:"Weight (kg)",lifeStage:"Life stage",activity:"Activity / life stage (MER factor)",factorHint:"Labels show the actual factor used.",infoTip:"Info (i): RER=70×kg^0.75; MER=RER×factor. Factors are a starting point—adjust by body condition & stool; special stages/diseases: follow your vet.",grams:"Grams/day",cups:"Cups/day",cupsNote:"Cups calculation needs the food energy density (kcal/100g or kcal/cup) and grams per cup (often on the bag). If unknown, rely on grams/day first.",density:"Optional: density for precise grams/cups",kcal100:"kcal / 100 g",kcalCup:"kcal / cup",gPerCup:"grams / cup",customToggle:"Use custom factor",customHint:"Only change if you know what you’re doing (懂则改，不懂别动)。",estNote:"Values marked (est.) are based on a typical density; use your bag’s numbers for precision."},switch:{title:"7-Day Gradual Switch",caution:"If stool is soft or pet seems unwell, hold that day or step back one day, then continue after recovery."},fb:{title:"Feedback",note:"Choose a category and send us details. No personal health data, please.",send:"Send mail",opt:{calc:"Calculator",copy:"Copy/Basis & Notes",switch:"7-Day Switch",bug:"Bug",idea:"Idea"}}},zh:{nav:{home:"首页",calc:"计算",switch:"7天换粮",feedback:"反馈"},ui:{lang:"语言"},home:{title:"喂养与换粮助手",pitch:"面向美国市场的信息性工具：把宠物食品/洗护标签转成可执行建议。非医疗建议。",kcal:"RER/MER 透明可解释",i18n:"多语言",mode:"单文件 SPA",quick:"快速开始",q1:"进入 计算 → 输入体重(kg) → 选择物种与活动系数。",q2:"查看 kcal/日 与 g/日。Cups/日 需要包装上的能量密度与每杯克数。",q3:"查看 7 天渐进换粮。如便便偏软或不适 → 保持当日或倒回一天。"},calc:{title:"喂养计算器",species:"物种",weight:"体重(kg)",lifeStage:"生命周期",activity:"活动/阶段（MER 系数）",factorHint:"选项名称直接展示所用系数。",infoTip:"提示（i）：RER=70×kg^0.75；MER=RER×系数。系数仅为起点，应结合体况/便便微调；特殊阶段/疾病遵从兽医。",grams:"克/日",cups:"杯/日",cupsNote:"计算杯数需要食品能量密度（kcal/100g 或 kcal/cup）与每杯克数（常见在包装袋上）；若未知，请先以 g/日 为准。",density:"可选：用于精算克/杯的密度参数",kcal100:"kcal / 100 g",kcalCup:"kcal / 杯",gPerCup:"克 / 杯",customToggle:"自定义系数",customHint:"懂则改，不懂别动。",estNote:"标注 (估) 的数值基于典型密度；使用包装标注可获得更精确结果。"},switch:{title:"7天渐进换粮",caution:"若便便偏软或不适，请保持当日或倒回一天，恢复后再继续。"},fb:{title:"反馈",note:"请选择分类并通过邮件发送问题/建议。请勿提交个人健康信息。",send:"发送邮件",opt:{calc:"计算器",copy:"文案/依据与说明",switch:"7天换粮",bug:"缺陷",idea:"想法"}}},es:{nav:{home:"Inicio",calc:"Cálculo",switch:"7 días",feedback:"Feedback"},ui:{lang:"Idioma"},home:{title:"Asistente de alimentación y cambio",pitch:"Herramienta informativa: convierte etiquetas en orientación accionable. No es consejo médico.",kcal:"RER/MER transparente",i18n:"Multi-idioma",mode:"SPA de un solo archivo",quick:"Inicio rápido",q1:"Ir a Cálculo → peso (kg) → especie y factor.",q2:"Revisa kcal/día y g/día. Las tazas requieren la densidad del alimento.",q3:"Plan de cambio gradual de 7 días. Si hay heces blandas → mantener o retroceder."},calc:{title:"Calculadora de alimentación",species:"Especie",weight:"Peso (kg)",lifeStage:"Etapa de vida",activity:"Actividad / etapa (factor MER)",factorHint:"Las etiquetas muestran el factor usado.",infoTip:"Info (i): RER=70×kg^0.75; MER=RER×factor. Punto de partida—ajustar por condición corporal y heces; etapas especiales/enfermedades: sigue a tu veterinario.",grams:"Gramos/día",cups:"Tazas/día",cupsNote:"Las tazas requieren densidad energética (kcal/100g o kcal/taza) y gramos por taza. Si es desconocido, usa g/día.",density:"Opcional: densidad para precisión",kcal100:"kcal / 100 g",kcalCup:"kcal / taza",gPerCup:"gramos / taza",customToggle:"Factor personalizado",customHint:"Cámbialo sólo si sabes lo que haces.",estNote:"(est.) usa densidad típica; usa tu bolsa para precisión."},switch:{title:"Cambio gradual 7 días",caution:"Si hay heces blandas o malestar, mantén el día o retrocede uno, y continúa tras mejorar."},fb:{title:"Comentarios",note:"Elige una categoría y envíanos detalles. Sin datos de salud personal, por favor.",send:"Enviar correo",opt:{calc:"Calculadora",copy:"Texto/Basis & Notes",switch:"Cambio 7 días",bug:"Error",idea:"Idea"}}},fr:{nav:{home:"Accueil",calc:"Calcul",switch:"7 jours",feedback:"Avis"},ui:{lang:"Langue"},home:{title:"Assistant d'alimentation & transition",pitch:"Outil informatif : transformer les étiquettes en conseils actionnables. Pas un avis médical.",kcal:"RER/MER transparent",i18n:"Multilingue",mode:"SPA fichier unique",quick:"Démarrage rapide",q1:"Aller à Calcul → poids (kg) → espèce & facteur.",q2:"Vérifier kcal/jour et g/jour. Les tasses nécessitent la densité du sac.",q3:"Plan de transition sur 7 jours. Selles molles ? Maintenir ou revenir d'une étape."},calc:{title:"Calculateur d'alimentation",species:"Espèce",weight:"Poids (kg)",lifeStage:"Stade de vie",activity:"Activité / stade (facteur MER)",factorHint:"Les étiquettes affichent le facteur utilisé.",infoTip:"Info (i) : RER=70×kg^0,75 ; MER=RER×facteur. Point de départ—ajuster selon l'état corporel & les selles ; stades spéciaux/maladies : suivre votre vétérinaire.",grams:"Grammes/jour",cups:"Tasses/jour",cupsNote:"Le calcul des tasses nécessite la densité énergétique et les grammes par tasse. Sinon, fiez-vous aux g/jour.",density:"Optionnel : densité pour précision",kcal100:"kcal / 100 g",kcalCup:"kcal / tasse",gPerCup:"grammes / tasse",customToggle:"Facteur personnalisé",customHint:"Ne changez que si nécessaire.",estNote:"(est.) basé sur densité typique ; utilisez les données du sac pour la précision."},switch:{title:"Transition 7 jours",caution:"Si selles molles ou malaise, maintenir la journée ou revenir d'un jour, puis poursuivre."},fb:{title:"Retour",note:"Choisissez une catégorie et envoyez-nous les détails. Pas de données de santé personnelles.",send:"Envoyer un mail",opt:{calc:"Calculateur",copy:"Texte/Basis & Notes",switch:"Transition 7 jours",bug:"Anomalie",idea:"Idée"}}}};
+/* ---------- I18N（同上版本） ---------- */
+const I18N={en:{nav:{home:"Home",calc:"Calc",switch:"7-Day",feedback:"Feedback"},ui:{lang:"Language"},home:{title:"Feeding & Switch Helper",pitch:"Informational tool for the U.S. market: turn pet food / grooming labels into actionable guidance. Not medical advice.",kcal:"RER/MER transparent",i18n:"Multi-language",mode:"Single-file SPA",quick:"Quick start",q1:"Go to Calc → enter weight (kg) → pick species & activity factor.",q2:"Review kcal/day and grams/day. Cups/day requires density info from the bag.",q3:"See 7-Day gradual switch plan. If stool soft or upset → hold or step back."},calc:{title:"Feeding Calculator",species:"Species",weight:"Weight (kg)",lifeStage:"Life stage",activity:"Activity / life stage (MER factor)",factorHint:"Labels show the actual factor used.",infoTip:"Info (i): RER=70×kg^0.75; MER=RER×factor. Factors are a starting point—adjust by body condition & stool; special stages/diseases: follow your vet.",grams:"Grams/day",cups:"Cups/day",cupsNote:"Cups calculation needs the food energy density (kcal/100g or kcal/cup) and grams per cup. If unknown, rely on grams/day first.",density:"Optional: density for precise grams/cups",kcal100:"kcal / 100 g",kcalCup:"kcal / cup",gPerCup:"grams / cup",customToggle:"Use custom factor",customHint:"Only change if you know what you’re doing (懂则改，不懂别动)。",estNote:"Values marked (est.) are based on a typical density; use your bag’s numbers for precision."},switch:{title:"7-Day Gradual Switch",caution:"If stool is soft or pet seems unwell, hold that day or step back one day, then continue after recovery."},fb:{title:"Feedback",note:"Choose a category and send us details. No personal health data, please.",send:"Send mail",opt:{calc:"Calculator",copy:"Copy/Basis & Notes",switch:"7-Day Switch",bug:"Bug",idea:"Idea"}}},zh:{nav:{home:"首页",calc:"计算",switch:"7天换粮",feedback:"反馈"},ui:{lang:"语言"},home:{title:"喂养与换粮助手",pitch:"面向美国市场的信息性工具：把宠物食品/洗护标签转成可执行建议。非医疗建议。",kcal:"RER/MER 透明可解释",i18n:"多语言",mode:"单文件 SPA",quick:"快速开始",q1:"进入 计算 → 输入体重(kg) → 选择物种与活动系数。",q2:"查看 kcal/日 与 g/日。Cups/日 需要包装上的能量密度与每杯克数。",q3:"查看 7 天渐进换粮。如便便偏软或不适 → 保持当日或倒回一天。"},calc:{title:"喂养计算器",species:"物种",weight:"体重(kg)",lifeStage:"生命周期",activity:"活动/阶段（MER 系数）",factorHint:"选项名称直接展示所用系数。",infoTip:"提示（i）：RER=70×kg^0.75；MER=RER×系数。系数仅为起点，应结合体况/便便微调；特殊阶段/疾病遵从兽医。",grams:"克/日",cups:"杯/日",cupsNote:"计算杯数需要食品能量密度（kcal/100g 或 kcal/cup）与每杯克数；若未知，请先以 g/日 为准。",density:"可选：用于精算克/杯的密度参数",kcal100:"kcal / 100 g",kcalCup:"kcal / 杯",gPerCup:"克 / 杯",customToggle:"自定义系数",customHint:"懂则改，不懂别动。",estNote:"标注 (估) 的数值基于典型密度；使用包装标注可获得更精确结果。"},switch:{title:"7天渐进换粮",caution:"若便便偏软或不适，请保持当日或倒回一天，恢复后再继续。"},fb:{title:"反馈",note:"请选择分类并通过邮件发送问题/建议。请勿提交个人健康信息。",send:"发送邮件",opt:{calc:"计算器",copy:"文案/依据与说明",switch:"7天换粮",bug:"缺陷",idea:"想法"}}},es:{nav:{home:"Inicio",calc:"Cálculo",switch:"7 días",feedback:"Feedback"},ui:{lang:"Idioma"},home:{title:"Asistente de alimentación y cambio",pitch:"Herramienta informativa…"},calc:{title:"Calculadora de alimentación",species:"Especie",weight:"Peso (kg)",lifeStage:"Etapa de vida",activity:"Actividad / etapa (factor MER)",factorHint:"…",infoTip:"…",grams:"Gramos/día",cups:"Tazas/día",cupsNote:"…",density:"Opcional…",kcal100:"kcal / 100 g",kcalCup:"kcal / taza",gPerCup:"gramos / taza",customToggle:"Factor personalizado",customHint:"…",estNote:"…"},switch:{title:"Cambio gradual 7 días",caution:"…"},fb:{title:"Comentarios",note:"…",send:"Enviar correo",opt:{calc:"Calculadora",copy:"Texto/Basis & Notes",switch:"Cambio 7 días",bug:"Error",idea:"Idea"}}},fr:{nav:{home:"Accueil",calc:"Calcul",switch:"7 jours",feedback:"Avis"},ui:{lang:"Langue"},home:{title:"Assistant d'alimentation & transition",pitch:"…"},calc:{title:"Calculateur d'alimentation",species:"Espèce",weight:"Poids (kg)",lifeStage:"Stade de vie",activity:"Activité / stade (facteur MER)",factorHint:"…",infoTip:"…",grams:"Grammes/jour",cups:"Tasses/jour",cupsNote:"…",density:"Optionnel…",kcal100:"kcal / 100 g",kcalCup:"kcal / tasse",gPerCup:"grammes / tasse",customToggle:"Facteur personnalisé",customHint:"…",estNote:"…"},switch:{title:"Transition 7 jours",caution:"…"},fb:{title:"Retour",note:"…",send:"Envoyer un mail",opt:{calc:"Calculateur",copy:"Texte/Basis & Notes",switch:"Transition 7 jours",bug:"Anomalie",idea:"Idée"}}}};
 
-/* ---------- 因子文案映射（解决中英混杂） ---------- */
+/* ---------- 因子文案映射（与上个版本相同） ---------- */
 const FACTOR_TEXT = {
   en: { rest:'Resting', normal:'Normal', active:'Active',
     hints:{
@@ -311,6 +300,13 @@ const $$=(s,r=document)=>Array.from(r.querySelectorAll(s));
 const save=(k,v)=>{ try{ localStorage.setItem(k, JSON.stringify(v)); }catch{} };
 const load=(k,d=null)=>{ try{ const v=localStorage.getItem(k); return v==null?d:JSON.parse(v); }catch{ return d; } };
 
+/* 按物种×阶段生成分组 key */
+function factorKey(){
+  const sp = $('#species')?.value || 'dog';
+  const st = $('#lifeStageLbl')?.value || 'adult';
+  return `factor_${sp}_${st}`;
+}
+
 /* ---------- router ---------- */
 function route(){
   const hash=(location.hash||'#home').split('&')[0];
@@ -330,9 +326,7 @@ function setLang(l){
     let cur=I18N[lang]; for(const k of path){cur=cur?.[k];}
     if(typeof cur==='string') node.textContent=cur;
   });
-  // 因子卡片依赖语言，需要重渲染
-  renderFactors();
-  calc();
+  renderFactors(); calc();
 }
 function initLang(){
   const ql=new URLSearchParams(location.search).get('lang');
@@ -343,48 +337,24 @@ function initLang(){
 }
 $('#langSel')?.addEventListener('change',e=>setLang(e.target.value));
 
-/* ---------- 因子定义（只存值，不存文案） ---------- */
+/* ---------- 因子定义 ---------- */
 const SAFETY_MIN_FACTOR=0.8, SAFETY_MAX_FACTOR=6.0;
 const KCAL_PER_100G_DEFAULT=350;
 
 const STAGE_FACTORS={
   dog:{
-    adult:[
-      {key:'rest',value:1.3},
-      {key:'normal',value:1.6},
-      {key:'active',value:2.0}
-    ],
-    puppy:[
-      {key:'rest',value:1.6},
-      {key:'normal',value:2.5},
-      {key:'active',value:3.0}
-    ],
-    senior:[
-      {key:'rest',value:1.2},
-      {key:'normal',value:1.4},
-      {key:'active',value:1.6}
-    ]
+    adult:[ {key:'rest',value:1.3},{key:'normal',value:1.6},{key:'active',value:2.0} ],
+    puppy:[ {key:'rest',value:1.6},{key:'normal',value:2.5},{key:'active',value:3.0} ],
+    senior:[ {key:'rest',value:1.2},{key:'normal',value:1.4},{key:'active',value:1.6} ]
   },
   cat:{
-    adult:[
-      {key:'rest',value:1.1},
-      {key:'normal',value:1.3},
-      {key:'active',value:1.6}
-    ],
-    puppy:[
-      {key:'rest',value:1.2},
-      {key:'normal',value:1.3},
-      {key:'active',value:1.6}
-    ],
-    senior:[
-      {key:'rest',value:1.1},
-      {key:'normal',value:1.2},
-      {key:'active',value:1.3}
-    ]
+    adult:[ {key:'rest',value:1.1},{key:'normal',value:1.3},{key:'active',value:1.6} ],
+    puppy:[ {key:'rest',value:1.2},{key:'normal',value:1.3},{key:'active',value:1.6} ],
+    senior:[ {key:'rest',value:1.1},{key:'normal',value:1.2},{key:'active',value:1.3} ]
   }
 };
 
-/* ---------- 渲染因子卡片（按当前语言本地化文案） ---------- */
+/* ---------- 渲染因子卡片（语言本地化 + 分组记忆） ---------- */
 function renderFactors(){
   const lang = load('lang','en');
   const L = FACTOR_TEXT[lang] || FACTOR_TEXT.en;
@@ -396,11 +366,10 @@ function renderFactors(){
 
   const H = (L.hints && L.hints[species] && L.hints[species][stage]) ? L.hints[species][stage] : {};
 
-  defs.forEach((f,i)=>{
-    const name = L[f.key] || f.key;        // 文案：例如 “静止/正常/活跃”
-    const hint = H[f.key] || '';           // 小提示
+  defs.forEach((f)=>{
+    const name = L[f.key] || f.key;
+    const hint = H[f.key] || '';
     const label = `${name} (${f.value})`;
-
     const w=document.createElement('label');
     w.className='label-inline';
     w.innerHTML=`
@@ -409,12 +378,12 @@ function renderFactors(){
     box.appendChild(w);
   });
 
-  // 恢复上次选择：优先 custom → factor → 默认 i===1
-  const savedFactor = load('factor', null);
+  // 分组记忆：优先使用 factor_${species}_${stage}
+  const grouped = load(factorKey(), null);
   const radios = $$('input[name="factor"]', box);
-  let checked = false;
-  if(savedFactor){
-    for(const r of radios){ if(parseFloat(r.value)===parseFloat(savedFactor)){ r.checked=true; checked=true; break; } }
+  let checked=false;
+  if(grouped){
+    for(const r of radios){ if(parseFloat(r.value)===parseFloat(grouped)){ r.checked=true; checked=true; break; } }
   }
   if(!checked && radios[1]) radios[1].checked=true; // 默认第二项
 }
@@ -468,14 +437,15 @@ function calc(){
   $('#estNote').hidden=!est;
 }
 
-/* ---------- 事件 + 本地记忆 ---------- */
+/* ---------- 事件 + 本地记忆（含分组系数） ---------- */
 function wireAndRestore(){
-  // 恢复
+  // 恢复基础字段
   const species=load('species','dog'); $('#species').value=species;
   const wkg=load('wkg',''); if(wkg!=='') $('#wkg').value=wkg;
   const stage=load('lifeStageLbl','adult'); $('#lifeStageLbl').value=stage;
 
-  renderFactors(); // 渲染后再恢复勾选
+  renderFactors();
+
   const useCustom=!!load('useCustom', false); $('#useCustom').checked=useCustom;
   $('#customFactor').disabled=!useCustom;
   const cfv=load('customFactor',''); if(cfv!=='') $('#customFactor').value=cfv;
@@ -483,40 +453,49 @@ function wireAndRestore(){
   const kcalCup=load('kcalCup',''); if(kcalCup!=='') $('#kcalCup').value=kcalCup;
   const gPerCup=load('gPerCup',''); if(gPerCup!=='') $('#gPerCup').value=gPerCup;
 
-  // 事件（保存+计算）
+  // 绑定事件（保存 + 计算）
   $('#species')?.addEventListener('change',e=>{ save('species', e.target.value); renderFactors(); calc(); });
   $('#lifeStageLbl')?.addEventListener('change',e=>{ save('lifeStageLbl', e.target.value); renderFactors(); calc(); });
   $('#wkg')?.addEventListener('input',e=>{ save('wkg', e.target.value); calc(); });
+
   document.addEventListener('change',e=>{
     if(e.target.name==='factor'){
-      save('factor', parseFloat(e.target.value));
-      // 切换 factor 时，如果处于自定义模式，也允许继续显示自定义数值；计算使用 currentFactor()
+      const val = parseFloat(e.target.value);
+      save(factorKey(), val);      // 分组保存
+      save('factor', val);         // 兼容旧键
       calc();
     }
   });
+
   ['kcal100','kcalCup','gPerCup','customFactor'].forEach(id=>{
     $('#'+id)?.addEventListener('input',e=>{ save(id, e.target.value); calc(); });
   });
+
   $('#useCustom')?.addEventListener('change',e=>{
     const on=e.target.checked; save('useCustom', on);
     $('#customFactor').disabled=!on;
-    // 取消勾选自定义时，确保有一个factor被选中（若无就默认第二项）
     if(!on){
       const checked=document.querySelector('input[name="factor"]:checked');
       if(!checked){
         const radios=$$('input[name="factor"]');
-        if(radios[1]){ radios[1].checked=true; save('factor', parseFloat(radios[1].value)); }
+        if(radios[1]){ radios[1].checked=true; const v=parseFloat(radios[1].value); save(factorKey(), v); save('factor', v); }
       }
     }
     calc();
   });
 
-  // Reset saved：清空本地保存并刷新当前表单
+  // Reset：清空所有保存（含 factor_ 前缀）
   $('#resetSaved')?.addEventListener('click', (e) => {
     e.preventDefault();
+    try{
+      const keys = Object.keys(localStorage);
+      keys.forEach(k=>{
+        if(/^factor_/.test(k)) localStorage.removeItem(k);
+      });
+    }catch{}
     ['species','wkg','lifeStageLbl','factor','kcal100','kcalCup','gPerCup','useCustom','customFactor','lang']
       .forEach(k => { try{ localStorage.removeItem(k);}catch{} });
-    // 恢复默认 → 重新渲染与计算
+    // 恢复默认并重算
     $('#species').value='dog';
     $('#lifeStageLbl').value='adult';
     $('#wkg').value='';
@@ -526,7 +505,6 @@ function wireAndRestore(){
     calc();
   });
 
-  // 先算一次
   calc();
 }
 
@@ -546,15 +524,16 @@ Details:
 /* ---------- boot ---------- */
 (function boot(){
   if(!location.hash) location.hash='#home';
-  route();              // 显示对应 tab
-  initLang();           // 语言（含恢复）
-  wireAndRestore();     // 表单恢复 + 事件 + 记忆 + 计算
+  route();
+  const langSaved = load('lang', null);
+  initLang();           // 语言（含恢复或参数）
+  wireAndRestore();     // 表单恢复 + 分组记忆 + 计算
 })();
 </script>
 
 <!--
 DOC_SYNC_INDEX.md (append)
-- 2025-10-06 — hotfix-20251006i: remember prefs; add "Reset saved"; localize factor card labels; no behavior change.
+- 2025-10-06 — hotfix-20251006j: remember factor per species×life-stage; reset clears all factor_* keys.
 -->
 </body>
 </html>


### PR DESCRIPTION
# PR Title
feat: feeding calc UX — Dog/Cat defaults + basis notes + custom factor & cups precision

## What
- Calc: Dog/Cat defaults (Dog 1.6 / Cat 1.3), factor labels show values
- Basis & Notes (EN/zh), disclaimers
- 7-Day caution bolded
- Copy: cups requirement note
- **New:** custom MER factor (checkbox + number), guarded 0.8–6.0
- **New:** optional density inputs (kcal/100g OR kcal/cup + g/cup) → precise grams/cups; show (est.) when using typical density

## Why
Improve trust & explainability; keep informational boundary; enable precision without forcing inputs.

## Checklist
- [ ] Default language = en; `?lang` + localStorage OK
- [ ] Routes: `#home/#calc/#switch/#feedback`
- [ ] RER=70×kg^0.75; MER=RER×factor
- [ ] Defaults: Dog 1.6 / Cat 1.3; labels show numeric factors
- [ ] Custom factor clamped 0.8–6.0; toggling clears radios
- [ ] Cups only when grams/cup known; otherwise `—`
- [ ] (est.) shown when typical density used
- [ ] Single-file SPA intact; 404 compatibility retained
- [ ] Signed commits; Squash merge
